### PR TITLE
#86bzfqhv6: Add proxy host when measuring latency

### DIFF
--- a/src/gologin.js
+++ b/src/gologin.js
@@ -639,7 +639,7 @@ export class GoLogin {
 
     debug('Profile ready. Path: ', profilePath, 'PROXY', JSON.stringify(get(preferences, 'gologin.proxy')));
 
-    return profilePath;
+    return profile;
   }
 
   async commitProfile() {
@@ -1373,12 +1373,12 @@ export class GoLogin {
       throw new Error(`Orbita browser is not exists on path ${ORBITA_BROWSER}, check executablePath param`);
     }
 
-    await this.createStartup();
+    const profile = await this.createStartup();
     // await this.createBrowserExtension();
     const wsUrl = await this.spawnBrowser();
     this.setActive(true);
 
-    return { status: 'success', wsUrl };
+    return { status: 'success', wsUrl, profile };
   }
 
   async startLocal() {


### PR DESCRIPTION
Example of metrics endpoint response:
```
# HELP response_time_seconds Duration of HTTP requests in seconds
# TYPE response_time_seconds histogram
response_time_seconds_bucket{le="0.5",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="0.75",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="1",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="1.25",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="1.5",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="1.75",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="2",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="2.25",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="2.5",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="2.75",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="3",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="3.5",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="4",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="4.5",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="5",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_bucket{le="+Inf",proxy_host="gw-open.ntnt.io"} 1
response_time_seconds_sum{proxy_host="gw-open.ntnt.io"} 0.000038792
response_time_seconds_count{proxy_host="gw-open.ntnt.io"} 1
```
(this is only part with new label)